### PR TITLE
Display notifications in the foreground for iOS users

### DIFF
--- a/src/Notifications/FCM/NotificationFCM.php
+++ b/src/Notifications/FCM/NotificationFCM.php
@@ -240,6 +240,8 @@ class NotificationFCM
                         'payload' => [
                             'aps' => [
                                 'badge' => 42,
+                                "mutableContent" => 1,
+                                "contentAvailable"=> 1,
                             ],
                         ],
                     ],


### PR DESCRIPTION
Display notifications in the foreground for iOS users