### PR TITLE
MA push notification data includes incorrect badge data

### DIFF
--- a/src/Notifications/FCM/NotificationFCM.php
+++ b/src/Notifications/FCM/NotificationFCM.php
@@ -239,7 +239,6 @@ class NotificationFCM
                         ],
                         'payload' => [
                             'aps' => [
-                                'badge' => 42,
                                 "mutableContent" => 1,
                                 "contentAvailable"=> 1,
                             ],


### PR DESCRIPTION
[BE-304](https://musora.atlassian.net/browse/BE-304)

Removed the badge info from the notification payload

